### PR TITLE
fix: add dapp modal button

### DIFF
--- a/src/renderer/routes/Home/components/PortfolioView.tsx
+++ b/src/renderer/routes/Home/components/PortfolioView.tsx
@@ -19,7 +19,8 @@ const PortfolioWrapper = styled.div`
   position: relative;
   height: 100%;
   .scroll-container {
-    overflow: overlay;
+    // don't use overflow: overlay, it will cause zIndex problem
+    overflow: auto;
     height: 100%;
     padding-right: 27px;
     padding-top: 28px;


### PR DESCRIPTION
解决以下问题：
> Mac，从资产页绑定dapp入口，添加dapp时，Add按钮的A字母处无法点击；Go back and bind dapp的n字母处无法点击

当使用 `overflow:overlay` 时，这个滚动条貌似是个最高层级（透明）。如果上面有弹框，重叠的部分会点击失效。改成 `overflow: auto` 可以解决问题。原因未知。

需要确认改成 `overflow: auto` 对资产页有无影响。