### PR TITLE
feat: disable dialogs for invisible browserView.

### DIFF
--- a/src/main/utils/appNetwork.ts
+++ b/src/main/utils/appNetwork.ts
@@ -44,6 +44,7 @@ const checkingProxyViewReady = getSessionInsts().then(
         session: checkingProxySession,
         sandbox: true,
         nodeIntegration: false,
+        disableDialogs: true,
       },
     });
 
@@ -66,6 +67,7 @@ export async function checkUrlViaBrowserView(
         session: checkingViewSession,
         sandbox: true,
         nodeIntegration: false,
+        disableDialogs: true,
       },
     });
   }

--- a/src/renderer/components/DappView/PreviewWebview.tsx
+++ b/src/renderer/components/DappView/PreviewWebview.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 const webviewWebPreferencesAttr = stringifyWebPreferences({
   ...SAFE_WEBPREFERENCES,
-  disableDialogs: false,
+  disableDialogs: true,
 });
 
 const Container = styled.div`


### PR DESCRIPTION
avoid `window.alert` trigger system dialog on adding dapps such as `https://offline-json-tools.wanpos.xyz/`