### PR TITLE
feat: remove fetch faviconBase64

### DIFF
--- a/src/main/utils/dapps.ts
+++ b/src/main/utils/dapps.ts
@@ -295,32 +295,32 @@ export async function detectDapp(
   }
 
   // TODO: if existed, fetch the url and store as base64
-  if (!data.faviconUrl) {
-    const { iconInfo, faviconUrl, faviconBase64 } = await parseWebsiteFavicon(
-      finalOrigin,
-      {
-        timeout: 3000, // 如果之前的流程取不到 favicon，这里大概率也取不到，所以直接 3s 超时即可
-        proxy: proxyOnGrab,
-      }
-    );
+  // if (!data.faviconUrl) {
+  //   const { iconInfo, faviconUrl, faviconBase64 } = await parseWebsiteFavicon(
+  //     finalOrigin,
+  //     {
+  //       timeout: 3000, // 如果之前的流程取不到 favicon，这里大概率也取不到，所以直接 3s 超时即可
+  //       proxy: proxyOnGrab,
+  //     }
+  //   );
 
-    data.icon = iconInfo;
-    data.faviconUrl = faviconUrl || fallbackFavicon;
-    data.faviconBase64 = faviconBase64;
-  } else if (!data.faviconBase64) {
-    await fetchImageBuffer(data.faviconUrl, {
-      timeout: 3000, // base64 非必须，3s 取不到直接超时就好
-      proxy: proxyOnGrab,
-    })
-      .then((faviconBuf) => {
-        data.faviconBase64 = nativeImage
-          .createFromBuffer(faviconBuf)
-          .toDataURL();
-      })
-      .catch((error) => {
-        console.error(`[detectDapp] fetch favicon error occured: `, error);
-      });
-  }
+  //   data.icon = iconInfo;
+  //   data.faviconUrl = faviconUrl || fallbackFavicon;
+  //   data.faviconBase64 = faviconBase64;
+  // } else if (!data.faviconBase64) {
+  //   await fetchImageBuffer(data.faviconUrl, {
+  //     timeout: 3000, // base64 非必须，3s 取不到直接超时就好
+  //     proxy: proxyOnGrab,
+  //   })
+  //     .then((faviconBuf) => {
+  //       data.faviconBase64 = nativeImage
+  //         .createFromBuffer(faviconBuf)
+  //         .toDataURL();
+  //     })
+  //     .catch((error) => {
+  //       console.error(`[detectDapp] fetch favicon error occured: `, error);
+  //     });
+  // }
 
   return { data };
 }


### PR DESCRIPTION
1. 如果 browserView 都抓不到 favicon 的话这里的补偿基本不可能抓得到，所以直接拿掉
2. favIcon 的 base64 是非必要内容，现在反而会因为 cloudflare 的存在（因为抓 base64 是基于 fetch/xhr 的）导致抓取逻辑超时导致 Dapp 加载很久，所以也直接拿掉