### PR TITLE
feat: downgrade electron to v22 to avoid window manager issues on higher version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,7 @@
         "css-loader": "^6.7.1",
         "css-minimizer-webpack-plugin": "^4.0.0",
         "detect-port": "^1.3.0",
-        "electron": "^24.8.4",
+        "electron": "^22.3.25",
         "electron-builder": "^23.3.3",
         "electron-devtools-installer": "^3.2.0",
         "electron-notarize": "^1.2.1",
@@ -11069,14 +11069,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "24.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.8.4.tgz",
-      "integrity": "sha512-xalsPCJ7WYrGoUSORiEqCv1tkzw1VpNfUBchqNOJwX8laveKsQUjZqwP7Z071Q8rKsegHt17TlBYCkkHY1X3pg==",
+      "version": "22.3.25",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.25.tgz",
+      "integrity": "sha512-AjrP7bebMs/IPsgmyowptbA7jycTkrJC7jLZTb5JoH30PkBC6pZx/7XQ0aDok82SsmSiF4UJDOg+HoLrEBiqmg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^16.11.26",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -11681,9 +11681,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "18.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
-      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
+      "version": "16.18.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.54.tgz",
+      "integrity": "sha512-oTmGy68gxZZ21FhTJVVvZBYpQHEBZxHKTsGshobMqm9qWpbqdZsA5jvsuPZcHu0KwpmLrOHWPdEfg7XDpNT9UA==",
       "dev": true
     },
     "node_modules/electronmon": {
@@ -35607,20 +35607,20 @@
       }
     },
     "electron": {
-      "version": "24.8.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-24.8.4.tgz",
-      "integrity": "sha512-xalsPCJ7WYrGoUSORiEqCv1tkzw1VpNfUBchqNOJwX8laveKsQUjZqwP7Z071Q8rKsegHt17TlBYCkkHY1X3pg==",
+      "version": "22.3.25",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.25.tgz",
+      "integrity": "sha512-AjrP7bebMs/IPsgmyowptbA7jycTkrJC7jLZTb5JoH30PkBC6pZx/7XQ0aDok82SsmSiF4UJDOg+HoLrEBiqmg==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^16.11.26",
         "extract-zip": "^2.0.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.18.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
-          "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
+          "version": "16.18.54",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.54.tgz",
+          "integrity": "sha512-oTmGy68gxZZ21FhTJVVvZBYpQHEBZxHKTsGshobMqm9qWpbqdZsA5jvsuPZcHu0KwpmLrOHWPdEfg7XDpNT9UA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
     "css-loader": "^6.7.1",
     "css-minimizer-webpack-plugin": "^4.0.0",
     "detect-port": "^1.3.0",
-    "electron": "^24.8.4",
+    "electron": "^22.3.25",
     "electron-builder": "^23.3.3",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.2.1",

--- a/patches/@debank+common+0.3.35.patch
+++ b/patches/@debank+common+0.3.35.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@debank/common/dist/chain-data.js b/node_modules/@debank/common/dist/chain-data.js
-index 62ee511..8f43f7a 100644
+index f2d779b..ef50eb1 100644
 --- a/node_modules/@debank/common/dist/chain-data.js
 +++ b/node_modules/@debank/common/dist/chain-data.js
 @@ -54,7 +54,7 @@ export var CHAINS_ENUM;
@@ -11,7 +11,7 @@ index 62ee511..8f43f7a 100644
      CHAINS_ENUM["OAS"] = "OAS";
      CHAINS_ENUM["ZORA"] = "ZORA";
      CHAINS_ENUM["LINEA"] = "LINEA";
-@@ -974,22 +974,22 @@ export const CHAINS_RAW = {
+@@ -978,22 +978,22 @@ export const CHAINS_RAW = {
              "1559": true,
          },
      },


### PR DESCRIPTION
# security
sync fixes for heap buffer issues about webp

https://github.com/electron/electron/pull/39689
https://github.com/electron/electron/releases/tag/v22.3.24 https://github.com/electron/electron/releases/tag/v22.3.25

https://github.com/electron/electron/pull/40025