### PR TITLE
docs: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Join our Discord: https://discord.com/invite/seFBCWmUre
 
 ## License
 
-[MIT](https://github.com/RabbyHub/RabbyDesktop/blob/publish/prod/LICENSE) © [Rabby]
+- [MIT](https://github.com/RabbyHub/RabbyDesktop/blob/publish/prod/LICENSE) © [Rabby]
 
 [github-actions-status]: https://github.com/RabbyHub/RabbyDesktop/workflows/Test/badge.svg
 [github-actions-url]: https://github.com/RabbyHub/RabbyDesktop/actions

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Join our Discord: https://discord.com/invite/seFBCWmUre
 
 ## License
 
-MIT © [Rabby]
+[MIT](https://github.com/RabbyHub/RabbyDesktop/blob/publish/prod/LICENSE) © [Rabby]
 
 [github-actions-status]: https://github.com/RabbyHub/RabbyDesktop/workflows/Test/badge.svg
 [github-actions-url]: https://github.com/RabbyHub/RabbyDesktop/actions


### PR DESCRIPTION
I added the license link because it's nowhere to be found, also the Rabby link in the license field is unnecessary in my opinion, I just didn't want to remove it